### PR TITLE
test: authenticate GitHub client when GITHUB_TOKEN is set

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,3 +15,5 @@ jobs:
 
       - name: Test
         run: go test -v ./...
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/github_test.go
+++ b/github_test.go
@@ -2,22 +2,35 @@ package main
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/google/go-github/v89/github"
 	"github.com/hashicorp/go-version"
 )
 
+// newTestClient returns a client authenticated with GITHUB_TOKEN when it is
+// set, to avoid the 60 requests/hour unauthenticated rate limit. For public
+// repos the unauthenticated client works too, just with the lower limit.
+func newTestClient(t *testing.T) *github.Client {
+	t.Helper()
+	var opts []github.ClientOptionsFunc
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		opts = append(opts, github.WithAuthToken(token))
+	}
+	client, err := github.NewClient(opts...)
+	if err != nil {
+		t.Fatalf("Get error %v", err)
+	}
+	return client
+}
+
 func TestGetCurrentHugoVersion(t *testing.T) {
 	t.Parallel()
 	expected := "0.81.0"
 
 	var ctx = context.Background()
-	// for public repo, you don't need credentials
-	client, err := github.NewClient()
-	if err != nil {
-		t.Fatalf("Get error %v", err)
-	}
+	client := newTestClient(t)
 	// public repo as source
 	sourceOwner := "gohugoio"
 	sourceRepo := "hugo"
@@ -37,11 +50,7 @@ func TestGetCurrentDeployedVersion(t *testing.T) {
 	expected := "0.83.1"
 
 	var ctx = context.Background()
-
-	client, err := github.NewClient()
-	if err != nil {
-		t.Fatalf("Get error %v", err)
-	}
+	client := newTestClient(t)
 
 	real, _, err := getCurrentDeployedVersion(ctx, client, "abtris", "12ApiaryTest", "netlify.toml", "master")
 	if err != nil {


### PR DESCRIPTION
Follow-up to #180. The helper uses the v89 `ClientOptionsFunc` API, so it needs the bump from that PR — now on `master`.

**Problem**

`TestGetCurrentHugoVersion` and `TestGetCurrentDeployedVersion` call the live GitHub API with an unauthenticated client, which is capped at 60 requests/hour per IP. That cap is shared across everything using the runner's egress IP, so the `build` job can fail with `403 API rate limit exceeded` on a busy day with no change to the code. It also makes the suite hard to run locally: I hit that 403 on both tests while fixing #180.

**Change**

A `newTestClient` helper authenticates with `GITHUB_TOKEN` when the variable is set, and falls back to an unauthenticated client when it is not. Actions provides `secrets.GITHUB_TOKEN` automatically, so the workflow needs only the `env:` block — no repo secret to configure, and the token is still present (read-only) for pull requests from forks, which is all these read calls need. Contributors without a token keep the current behaviour at the current limit.

Authenticated requests get 5,000/hour, against a suite that makes two API calls: one `GetLatestRelease` and one `GetContents`.

**Verification**

- With a token, the full suite passes, including both live-API tests: `ok github.com/abtris/hugo-netlify-autoupdater 1.209s`
- With `GITHUB_TOKEN` unset, the non-network tests still pass, confirming the fallback compiles and runs.
- `gofmt` reports nothing.

**Still worth knowing**

A token fixes rate limits, not network dependence. `TestGetCurrentDeployedVersion` asserts the literal `0.83.1` from the live `abtris/12ApiaryTest`, so it still breaks offline or if that repo's `netlify.toml` changes. Making these hermetic means serving canned JSON from an `httptest` server, which trades away their value as integration smoke tests — worth doing only if they keep causing trouble.
