### PR TITLE
fix: key the Timestamp field in the commit author literal

### DIFF
--- a/github.go
+++ b/github.go
@@ -126,7 +126,7 @@ func pushCommit(ctx context.Context, client *github.Client, owner, repo string,
 	// Create the commit using the tree.
 	date := time.Now()
 	author := &github.CommitAuthor{
-		Date:  &github.Timestamp{date},
+		Date:  &github.Timestamp{Time: date},
 		Name:  &commiterName,
 		Email: &commiterEmail,
 	}


### PR DESCRIPTION
Fixes #185

`go vet` failed on the unkeyed composite literal in `pushCommit`:

```
github.go:130:11: github.com/google/go-github/v89/github.Timestamp struct literal uses unkeyed fields
```

`github.Timestamp` embeds `time.Time`, so the field is named `Time`. Naming it turns `&github.Timestamp{date}` into `&github.Timestamp{Time: date}` and the check passes.

**Verification**

`go vet ./...` is clean, `go build ./...` and `go test ./...` pass. Confirmed the two literals are the same value, not just both compilable: they compare equal, and a `CommitAuthor` holding the keyed one still marshals to `{"date":"2026-07-27T12:34:56Z"}`, so the commit author date on the wire is unchanged.

**Left alone**

`github.String` and `github.Bool` are deprecated in v89 in favour of `github.Ptr`, at six call sites in `github.go`. `go vet` does not flag them, so they are outside this issue. Happy to do that sweep separately if you want it.
